### PR TITLE
Only consider the first character as the diff symbol to avoid ambiguous interpretations

### DIFF
--- a/lib/makeup/lexers/diff_lexer.ex
+++ b/lib/makeup/lexers/diff_lexer.ex
@@ -13,7 +13,7 @@ defmodule Makeup.Lexers.DiffLexer do
   deleted = line_starting_with(["-", "<"], :generic_deleted)
   strong = line_starting_with("!", :generic_strong)
 
-  root_element_combinator =
+  line =
     choice([heading, inserted, deleted, strong, text_line()])
     |> map(:add_meta_diff_language)
 
@@ -22,14 +22,10 @@ defmodule Makeup.Lexers.DiffLexer do
   end
 
   @impl Makeup.Lexer
-  defparsec(:root_element, root_element_combinator)
+  defparsec(:root_element, line |> optional(newline()))
 
   @impl Makeup.Lexer
-  defparsec(
-    :root,
-    repeat(parsec(:root_element) |> concat(newline()))
-    |> choice([ignore(eos()), parsec(:root_element)])
-  )
+  defparsec(:root, repeat(line |> newline()) |> choice([eos(), line]))
 
   @impl Makeup.Lexer
   def postprocess(tokens, _opts \\ []), do: tokens

--- a/lib/makeup/lexers/diff_lexer/helper.ex
+++ b/lib/makeup/lexers/diff_lexer/helper.ex
@@ -23,7 +23,7 @@ defmodule Makeup.Lexers.DiffLexer.Helper do
   end
 
   defp rest_of_line(combinator \\ empty()) do
-    utf8_string(combinator, [not: 10, not: 13], min: 0)
+    utf8_string(combinator, [not: ?\n, not: ?\r], min: 0)
   end
 
   def newline(combinator \\ empty()) do

--- a/lib/makeup/lexers/diff_lexer/helper.ex
+++ b/lib/makeup/lexers/diff_lexer/helper.ex
@@ -11,7 +11,7 @@ defmodule Makeup.Lexers.DiffLexer.Helper do
   end
 
   def line_starting_with([_, _ | _] = start, token_type) do
-    List.wrap(start)
+    start
     |> Enum.map(&string/1)
     |> choice()
     |> rest_of_line()
@@ -23,11 +23,10 @@ defmodule Makeup.Lexers.DiffLexer.Helper do
   end
 
   defp rest_of_line(combinator \\ empty()) do
-    repeat(combinator, utf8_char([{:not, ?\n}, {:not, ?\r}]))
+    utf8_string(combinator, [not: 10, not: 13], min: 0)
   end
 
-  def newline() do
-    times(utf8_char([?\n, ?\r]), min: 1)
-    |> token(:whitespace)
+  def newline(combinator \\ empty()) do
+    concat(combinator, ascii_string([?\n, ?\r], min: 1) |> token(:whitespace))
   end
 end

--- a/lib/makeup/lexers/diff_lexer/helper.ex
+++ b/lib/makeup/lexers/diff_lexer/helper.ex
@@ -1,0 +1,33 @@
+defmodule Makeup.Lexers.DiffLexer.Helper do
+  @moduledoc false
+
+  import NimbleParsec
+  import Makeup.Lexer.Combinators
+
+  def line_starting_with(start, token_type) when is_binary(start) do
+    string(start)
+    |> rest_of_line()
+    |> token(token_type)
+  end
+
+  def line_starting_with([_, _ | _] = start, token_type) do
+    List.wrap(start)
+    |> Enum.map(&string/1)
+    |> choice()
+    |> rest_of_line()
+    |> token(token_type)
+  end
+
+  def text_line() do
+    rest_of_line() |> token(:text)
+  end
+
+  defp rest_of_line(combinator \\ empty()) do
+    repeat(combinator, utf8_char([{:not, ?\n}, {:not, ?\r}]))
+  end
+
+  def newline() do
+    times(utf8_char([?\n, ?\r]), min: 1)
+    |> token(:whitespace)
+  end
+end

--- a/test/makeup/lexers/diff_lexer_test.exs
+++ b/test/makeup/lexers/diff_lexer_test.exs
@@ -29,13 +29,13 @@ defmodule Makeup.Lexers.DiffLexerTest do
       end
     end
 
-    property "lexting a string with an insertion" do
+    property "lexing a string with an insertion" do
       check all text <- inserted() do
         assert [{:generic_inserted, %{}, ^text} | _] = lex(text)
       end
     end
 
-    property "lexting a string with a deletion" do
+    property "lexing a string with a deletion" do
       check all text <- deleted() do
         assert [{:generic_deleted, %{}, ^text}] = lex(text)
       end
@@ -78,10 +78,7 @@ defmodule Makeup.Lexers.DiffLexerTest do
       <deleted
       """
 
-      lexed =
-        text
-        |> lex()
-        |> Enum.reject(fn {type, _, _} -> type == :whitespace end)
+      lexed = lex(text, omit_whitespaces: true)
 
       assert [
                {:generic_heading, %{}, "diff --git a/setup"},
@@ -96,13 +93,40 @@ defmodule Makeup.Lexers.DiffLexerTest do
                {:generic_deleted, %{}, "<deleted"}
              ] = lexed
     end
+
+    test "marker expected in first position of each line" do
+      text = """
+       +text
+       -text
+      +-inserted
+      <>deleted
+       <text />
+      """
+
+      lexed = lex(text, omit_whitespaces: true)
+
+      assert [
+               {:text, %{}, " +text"},
+               {:text, %{}, " -text"},
+               {:generic_inserted, %{}, "+-inserted"},
+               {:generic_deleted, %{}, "<>deleted"},
+               {:text, %{}, " <text />"}
+             ] = lexed
+    end
   end
 
-  defp lex(text) do
+  defp lex(text, opts \\ []) do
     text
     |> DiffLexer.lex(group_prefix: "group")
     |> Postprocess.token_values_to_binaries()
     |> Enum.map(fn {type, meta, value} -> {type, Map.delete(meta, :language), value} end)
+    |> then(fn tokens ->
+      if Keyword.get(opts, :omit_whitespaces, false) do
+        Enum.reject(tokens, fn {type, _, _} -> type == :whitespace end)
+      else
+        tokens
+      end
+    end)
   end
 
   # Properties

--- a/test/makeup/lexers/diff_lexer_test.exs
+++ b/test/makeup/lexers/diff_lexer_test.exs
@@ -72,10 +72,10 @@ defmodule Makeup.Lexers.DiffLexerTest do
       +++ b/setup
       @@ -11,16 +11,22 @@ context line
        unchanged
-       + inserted
-       - deleted
-       > inserted
-       < deleted
+      +inserted
+      -deleted
+      >inserted
+      <deleted
       """
 
       lexed =
@@ -89,11 +89,11 @@ defmodule Makeup.Lexers.DiffLexerTest do
                {:generic_deleted, %{}, "--- a/setup"},
                {:generic_inserted, %{}, "+++ b/setup"},
                {:text, %{}, "@@ -11,16 +11,22 @@ context line"},
-               {:text, %{}, "unchanged"},
-               {:generic_inserted, %{}, "+ inserted"},
-               {:generic_deleted, %{}, "- deleted"},
-               {:generic_inserted, %{}, "> inserted"},
-               {:generic_deleted, %{}, "< deleted"}
+               {:text, %{}, " unchanged"},
+               {:generic_inserted, %{}, "+inserted"},
+               {:generic_deleted, %{}, "-deleted"},
+               {:generic_inserted, %{}, ">inserted"},
+               {:generic_deleted, %{}, "<deleted"}
              ] = lexed
     end
   end


### PR DESCRIPTION
# Proposed change

Previously, the first non-space character of each line was interpreted as a diff symbol (one of '>', '+', etc.). This is probably too lax, and can create ambiguous interpretations when the content of the diff'ed file itself begins with one of those characters. Only the first character of each line should be checked for a diff symbol. Anything else (like a space or any other character) should signal the whole line as plain text.

I got to this conclusion when I was reading the [LiveView 1.0 changelog](https://hexdocs.pm/phoenix_live_view/1.0.0-rc.6/changelog.html#migrating-from-phx-feedback-for). The coloring of the lines is a bit off, also highlighting some lines as deleted, while they are obviously unchanged lines, that happen to start with the `<` symbol.

<img width="486" alt="Scherm­afbeelding 2024-09-08 om 00 30 07" src="https://github.com/user-attachments/assets/9777458a-d211-48a2-945c-9c1c154962a2">

Just as a confirmation, github renders this [same markdown file](https://github.com/phoenixframework/phoenix_live_view/blob/main/CHANGELOG.md#core-components) with the mentioned line as plain text:

<img width="446" alt="Scherm­afbeelding 2024-09-08 om 00 28 49" src="https://github.com/user-attachments/assets/5651669b-2ed9-4cbc-99c6-196086cfa851">

# Implementation 

The current implementation uses NimbleParsec for parsing/lexing. I went the same way and tried to adhere to the current expectations (resulting in only some well intended changes in the tests). Somebody more knowledgeable in NimbleParsec could probably model the combinators in a simpler way. Especially the case when there is no newline at the end made me jump through some hoops. Feedback is very welcome.

I don't think this particular lexer benefits from using NimbleParsec, but this seemed like the least intrusive change. Simple string splitting on newlines, and then checking the first character of each line would also work for this simple case.

# Result

Trying  out the new rules for lexing results in this ex_doc view of the aforementioned changelog of LV 1.0:

<img width="440" alt="Scherm­afbeelding 2024-09-08 om 00 29 06" src="https://github.com/user-attachments/assets/e1fe2e96-6705-43c9-a14e-0933e1d4e646">

I'm glad to take any feedback. Or any reasons why this would not be a good idea. If this gets merged and released, the LV docs can be updated to reflect this new way of highlighting, and confuse less people in the process of updating to LV 1.0.